### PR TITLE
Adding blank option for country

### DIFF
--- a/src/templates/fields/address.eco
+++ b/src/templates/fields/address.eco
@@ -59,6 +59,7 @@
     <div class='fr_item_half'>
       <label class="fr_sub_label">Country</label>
       <select data-rv-value='model.value.country' data-width='100%'>
+        <option value=''>Select a country</option>
         <% for x in FormRenderer.ORDERED_COUNTRIES: %>
           <option value='<%= x %>'><%= ISOCountryNames[x] || '---' %></option>
         <% end %>


### PR DESCRIPTION
If I add an Address field with only the Country dropdown, and I live in the United States, Screendoor currently treats it as a validation error. We need a blank default option.

![screen shot 2015-03-09 at 1 11 36 pm](https://cloud.githubusercontent.com/assets/1328849/6561269/d6022f84-c65d-11e4-8d3d-8e1eb5ce6cd3.png)