### PR TITLE
Radio binder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "ajb-sanitize": "~1.0.1",
     "js-cookie": "~2.1.1",
     "backbone-deep-model": "~0.10.4",
-    "rivets-dobt": "dobtco/rivets#backport_getvalue",
+    "rivets-dobt": "1.0.0",
     "iso-country-names": "~0.1.0",
     "beforeunload.js": ">=0.1.1",
     "store.js": "~1.3.16",

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "ajb-sanitize": "~1.0.1",
     "js-cookie": "~2.1.1",
     "backbone-deep-model": "~0.10.4",
-    "rivets-dobt": "1.0.0",
+    "rivets-dobt": "dobtco/rivets#backport_getvalue",
     "iso-country-names": "~0.1.0",
     "beforeunload.js": ">=0.1.1",
     "store.js": "~1.3.16",

--- a/src/templates/fields/radio.eco
+++ b/src/templates/fields/radio.eco
@@ -1,1 +1,22 @@
-<%- JST["partials/options_field"](@) %>
+<% for option in @model.getOptions(): %>
+  <label class='fr_option control'>
+    <input type='radio' data-rv-dobtradio='model.value.checked' value="<%= option.label %>" />
+    <%= option.translated_label || option.label %>
+  </label>
+<% end %>
+
+<% if @model.get('include_other_option'): %>
+  <div class='fr_option fr_other_option'>
+    <label class='control'>
+      <input type='radio' data-rv-dobtradio="model.value.checked" value="other" />
+      <%= FormRenderer.t.other %>
+    </label>
+
+    <input
+        type='text'
+        data-rv-show='model.value.checked | eq <%= FormRenderer.t.other %>'
+        data-rv-input='model.value.other_text'
+        placeholder='<%= FormRenderer.t.write_here %>'
+    />
+  </div>
+<% end %>

--- a/src/templates/fields/radio.eco
+++ b/src/templates/fields/radio.eco
@@ -1,6 +1,10 @@
 <% for option in @model.getOptions(): %>
   <label class='fr_option control'>
-    <input type='radio' data-rv-dobtradio='model.value.checked' value="<%= option.label %>" />
+    <input
+      type='radio'
+      data-rv-dobtradiogroup='model.value.checked'
+      value='<%= option.label %>'
+    />
     <%= option.translated_label || option.label %>
   </label>
 <% end %>
@@ -9,19 +13,19 @@
   <div class='fr_option fr_other_option'>
     <label class='control'>
       <input
-          class='other-option'
-          type='radio'
-          value='other'
-          data-rv-dobtradio='model.value.checked'
+        type='radio'
+        class='other-option'
+        value='<%= FormRenderer.t.other %>'
+        data-rv-dobtradiogroup='model.value.checked'
       />
       <%= FormRenderer.t.other %>
     </label>
 
     <input
-        type='text'
-        data-rv-show='model.value.other_checked'
-        data-rv-input='model.value.other_text'
-        placeholder='<%= FormRenderer.t.write_here %>'
+      type='text'
+      data-rv-show='model.value.other_checked'
+      data-rv-input='model.value.other_text'
+      placeholder='<%= FormRenderer.t.write_here %>'
     />
   </div>
 <% end %>

--- a/src/templates/fields/radio.eco
+++ b/src/templates/fields/radio.eco
@@ -8,13 +8,18 @@
 <% if @model.get('include_other_option'): %>
   <div class='fr_option fr_other_option'>
     <label class='control'>
-      <input type='radio' data-rv-dobtradio="model.value.checked" value="other" />
+      <input
+          class='other-option'
+          type='radio'
+          value='other'
+          data-rv-dobtradio='model.value.checked'
+      />
       <%= FormRenderer.t.other %>
     </label>
 
     <input
         type='text'
-        data-rv-show='model.value.checked | eq <%= FormRenderer.t.other %>'
+        data-rv-show='model.value.other_checked'
         data-rv-input='model.value.other_text'
         placeholder='<%= FormRenderer.t.write_here %>'
     />

--- a/src/vendor_config.coffee
+++ b/src/vendor_config.coffee
@@ -31,20 +31,29 @@ rivets.binders.checkedarray =
     el.checked = _.contains(value, el.value)
 
   bind: (el) ->
-    if el.type == 'radio'
-      $(el).bind 'change.rivets', =>
-        @model.set @keypath, [el.value]
+    $(el).bind 'change.rivets', =>
+      val = @model.get(@keypath) || []
 
-    else
-      $(el).bind 'change.rivets', =>
-        val = @model.get(@keypath) || []
+      newVal = if el.checked
+                  _.uniq(val.concat(el.value))
+                else
+                  _.without(val, el.value)
 
-        newVal = if el.checked
-                   _.uniq(val.concat(el.value))
-                 else
-                   _.without(val, el.value)
+      @model.set @keypath, newVal
 
-        @model.set @keypath, newVal
+  unbind: (el) ->
+    $(el).unbind('change.rivets')
+
+
+rivets.binders.dobtradio =
+  publishes: true
+
+  routine: (el, value) ->
+    el.checked = _.contains(value, el.value)
+
+  bind: (el) ->
+    $(el).bind 'change.rivets', =>
+      @model.set @keypath, [el.value]
 
   unbind: (el) ->
     $(el).unbind('change.rivets')

--- a/src/vendor_config.coffee
+++ b/src/vendor_config.coffee
@@ -44,8 +44,7 @@ rivets.binders.checkedarray =
   unbind: (el) ->
     $(el).unbind('change.rivets')
 
-
-rivets.binders.dobtradio =
+rivets.binders.dobtradiogroup =
   publishes: true
 
   routine: (el, value) ->
@@ -55,10 +54,11 @@ rivets.binders.dobtradio =
     $(el).bind 'change.rivets', =>
       @model.set @keypath, [el.value]
 
-      if $(el).hasClass('other-option') and $(el).is(':checked')
+      if $(el).hasClass('other-option')
         @model.set 'value.other_checked', true
       else
-        @model.set 'value.other_checked', false
+        @model.unset 'value.other_checked'
+        @model.unset 'value.other_text'
 
   unbind: (el) ->
     $(el).unbind('change.rivets')

--- a/src/vendor_config.coffee
+++ b/src/vendor_config.coffee
@@ -55,6 +55,11 @@ rivets.binders.dobtradio =
     $(el).bind 'change.rivets', =>
       @model.set @keypath, [el.value]
 
+      if $(el).hasClass('other-option') and $(el).is(':checked')
+        @model.set 'value.other_checked', true
+      else
+        @model.set 'value.other_checked', false
+
   unbind: (el) ->
     $(el).unbind('change.rivets')
 


### PR DESCRIPTION
This is my attempt at fixing https://github.com/dobtco/screendoor-v2/issues/4557 with the least amount of hackery.

Its an alternative to the previous attempt at a fix: https://github.com/dobtco/formrenderer-base/pull/143

The radio view no longer shares a template with the checkboxes. Part of what made all of this confusing was the shared logic between checkboxes and radios.

Additionally, radio inputs no longer use `checked` or `checkedarray` binders. They now use a `dobtradiogroup` binder. Also note that the "other" radio input is bound to the same model value as the rest (`model.value.checked`). Having 'other' bound to a different model value caused the inputs to be in two separate logical groups, and introduced the need for hacks to deselect inputs via jquery. I wanted to fix this in the simplest possible way, so I created a new binder that simply checks if the selection event happened on the 'other' input (identified by a special class found in the template). If the event happens on the 'other' input, it sets `other_checked` to true.

Its also necessary to manually unset `other_checked` and `other_text` when the event is fired on a non-other field, because nothing in rivets will do that.

While working on this, I also discovered that the html `name` attribute is what groups radio fields. So technically, if we added a matching `name` attribute, no fancy logic would be necessary to make sure only one field is selected at a time. Unfortunately, we'd still need rivets to handle unsetting `other_text` if someone clicks 'other', then clicks one of the main radio inputs. Getting rivets to unset values is a huge pain...I thought I'd be able to make it work by backporting `getValue` from one of the later rivets PRs, but it didn't turn out to work as easily as I'd thought...it would require more digging through the rivets source code.

At this point I consider rivets a source of tech debt. Its a dependency we haven't updated in forever, so even getting up to date with it would take forever, but also, its not a very easy library to use and is no longer maintained. I don't think struggling to find a 'clean' way to make radio groups work within the much greater mess of this situation is really worth it.

**One concern that I have**: This change slightly modifies the payload for radio groups where the other option is selected - it will now send "Other" as one of the checked values. This is definitely worth discussing...but in my opinion it makes sense. We will possibly have to make some minor modifications in the screendoor rendering code to prevent showing the word "other" twice though...


*TODO*
- [ ] rebuild dist
- [ ] bump version