### PR TITLE
Upgrade CircleCI's node version to 6.10.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 6.10.2
+nodejs 6.11.4
 ruby 2.3.1

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 0.10.33

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 0.10.33
+    version: 6.10.2

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
 machine:
   node:
     version: 6.10.2
+
+dependencies:
+  pre:
+    - npm install grunt-cli

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.10.2
+    version: 6.11.4
 
 dependencies:
   pre:


### PR DESCRIPTION
6.10.2 is the node version we use locally (defined in `.tool-versions`). CircleCI builds are currently failing because phantomjs no longer supports 0.10.x (the default on circleci) -- we could downgrade phantom or upgrade node on our CI, so I think upgrading node makes way more sense. 

Since we didn't have a `circle.yml` file, I also needed to add `grunt` as a dependency for `grunt test` on circle to run successfully.