### PR TITLE
CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/dobtco/formrenderer-base
+    parallelism: 1
+    docker:
+      - image: circleci/node:6.14.3
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: formrenderer-dependency-cache-{{ checksum "package.json" }}
+
+      - run:
+          name: Install grunt-cli
+          command: npm install grunt-cli
+
+      - run:
+          name: Install dependencies
+          command: npm install
+
+      - save_cache:
+          key: formrenderer-dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+
+      - run:
+          name: test
+          command: npm test
+          
+      - store_artifacts:
+          path: test-results.xml
+          prefix: tests
+
+      - store_test_results:
+          path: test-results.xml

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  node:
-    version: 6.11.4
-
-dependencies:
-  pre:
-    - npm install grunt-cli


### PR DESCRIPTION
This is pretty straightforward as we don't do any of the deploy steps via CI.

The main issue here is the container uses node `6.14.3` and in dev we use veresion `6.11.4`. The options are:
- Upgrade our dev version
- Find a docker image that matches our version
- Build our own node image
- Use `Run` commands to manually downgrade node to our version

I can't think of a reason that having a higher node version would make failing tests pass so I think this is safe to start using now.

c.f. https://github.com/dobtco/dobt/issues/2387


