### PR TITLE
182 - Add event-stream resolution to 3.3.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,5 +31,8 @@
     "require_once": "0.0.1",
     "domurl": "2.1.7",
     "dompurify": "~1.0.2"
+  },
+  "resolutions": {
+    "event-stream": "3.3.4"
   }
 }


### PR DESCRIPTION
### Description:
https://github.com/dominictarr/event-stream/issues/116 an issue was identified where a bad actor become the maintainer of event-stream and included malicious code. We need to make sure we are using a version where this is not present.

### Changes:
Add a resolution to bower.json which will cause prior event-stream dependencies to resolve to a safe version on install.

### Issue Link:
c.f #183 